### PR TITLE
chore: Update actions/labeler to v6.0.1

### DIFF
--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labels/labeler.yaml


### PR DESCRIPTION
This PR updates the actions/labeler GitHub Action to version v6.0.1.