### PR TITLE
ci: pin actionlint go install sha

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,10 +22,12 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        'github\\.com/rhysd/actionlint/cmd/actionlint@(?<currentValue>v\\S+)',
+        'github\\.com/rhysd/actionlint/cmd/actionlint@(?<currentDigest>[a-f0-9]{40}) # (?<currentValue>v[^\\s]+)',
       ],
-      datasourceTemplate: 'github-releases',
+      autoReplaceStringTemplate: 'github.com/rhysd/actionlint/cmd/actionlint@{{{newDigest}}} # {{{newValue}}}',
+      datasourceTemplate: 'github-tags',
       depNameTemplate: 'rhysd/actionlint',
+      versioningTemplate: 'semver',
     },
     {
       customType: 'regex',

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Run actionlint
         if: github.event_name != 'pull_request'
         run: |
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
           "$(go env GOPATH)/bin/actionlint" -color
 
       - name: Run actionlint (reviewdog)


### PR DESCRIPTION
- pin the actionlint go install target to a commit SHA
- update the Renovate regex manager so it tracks the SHA for actionlint
