### PR TITLE
chore(renovate): group pre-commit and CI pins of shared lint tools

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -113,6 +113,33 @@
   ],
   packageRules: [
     {
+      matchDepNames: [
+        'crate-ci/typos',
+      ],
+      groupName: 'typos',
+    },
+    {
+      matchDepNames: [
+        'DavidAnson/markdownlint-cli2',
+        'markdownlint-cli2',
+      ],
+      groupName: 'markdownlint-cli2',
+    },
+    {
+      matchDepNames: [
+        'adrienverge/yamllint',
+        'yamllint',
+      ],
+      groupName: 'yamllint',
+    },
+    {
+      matchDepNames: [
+        'commitizen-tools/commitizen',
+        'commitizen',
+      ],
+      groupName: 'commitizen',
+    },
+    {
       matchFileNames: [
         '.github/workflows/**',
       ],


### PR DESCRIPTION
Each shared lint tool is currently pinned twice — once as a `pre-commit` hook in `.pre-commit-config.yaml` and once for the dedicated CI lint job in `ci.yaml` — and Renovate tracks the two pins through separate managers. The two pins can therefore drift apart between merges.

This groups each tool's pre-commit pin and CI pin under a shared `groupName`, so both are bumped in a single PR:

- typos
- markdownlint-cli2
- yamllint
- commitizen

These tools' pre-commit hook and CI artifact come from the same upstream and share a version, so grouping is safe.

tombi and ruff are intentionally left out: their pre-commit hook lives in a separate repository with an independent release cadence, so they need a different approach and are deferred.
