### PR TITLE
ci: run tombi TOML checks through reviewdog on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,6 +221,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout the main repository
@@ -233,11 +234,57 @@ jobs:
         with:
           version: '1.1.1'
 
-      - name: Check TOML format
-        run: tombi format --check
-
       - name: Lint TOML
+        if: github.event_name != 'pull_request'
         run: tombi lint
+
+      - name: Set up reviewdog
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+        with:
+          reviewdog_version: 'v0.21.0'
+
+      - name: Lint TOML (reviewdog)
+        if: github.event_name == 'pull_request'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NO_COLOR: '1'
+        run: |
+          lint_rc=0
+          tombi lint --quiet > /tmp/tombi-lint-report.txt 2>&1 || lint_rc=$?
+          gawk '
+            match($0, /^[[:space:]]*(Warning|Error):[[:space:]]*(.*)$/, m) {
+              severity = m[1]; message = m[2]; next
+            }
+            match($0, /^[[:space:]]*at[[:space:]]+(.*):([0-9]+):([0-9]+)/, m) {
+              printf "%s:%s:%s: %s: %s\n", m[1], m[2], m[3], severity, message
+            }
+          ' /tmp/tombi-lint-report.txt > /tmp/tombi-lint-report.efm.txt
+          reviewdog_rc=0
+          reviewdog < /tmp/tombi-lint-report.efm.txt \
+              -efm="%f:%l:%c: %m" \
+              -name=tombi-lint \
+              -reporter=github-pr-review \
+              -fail-level=error || reviewdog_rc=$?
+          if [ $lint_rc -ne 0 ] && [ ! -s /tmp/tombi-lint-report.efm.txt ]; then
+            echo "::error title=tombi::tombi lint failed before producing parseable diagnostics"
+            cat /tmp/tombi-lint-report.txt
+            exit $lint_rc
+          fi
+          exit $reviewdog_rc
+
+      - name: Format TOML
+        run: tombi format
+
+      - name: Suggest TOML format changes (reviewdog)
+        if: github.event_name == 'pull_request'
+        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1.24.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tool_name: tombi
+
+      - name: Check TOML format
+        run: git diff --exit-code
 
   lint-yaml:
     name: Lint YAML

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,6 +282,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tool_name: tombi
+          cleanup: 'false'
 
       - name: Check TOML format
         run: git diff --exit-code


### PR DESCRIPTION
Route the TOML (tombi) checks through reviewdog on pull requests, so findings show up as inline comments like the markdown, yaml, and typos jobs already do.

- Lint: fold tombi's two-line diagnostics into reviewdog's errorformat and report via `github-pr-review`.
- Format: apply `tombi format` in place and surface the diff as suggestions via `reviewdog/action-suggester`, then fail on any remaining diff.
- Unify the format check across events (`tombi format` + `git diff --exit-code`), and keep direct, hard-failing checks on push.
