### PR TITLE
fix(renovate): repair custom managers broken by unsupported prefix group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,7 @@
       matchStringsStrategy: 'recursive',
       matchStrings: [
         "uses: commitizen-tools/setup-cz@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '[^'\\s]+'",
-        "version: '(?<currentValue>[^'\\s]+)'",
+        "\\n\\s+version: '(?<currentValue>[^'\\s]+)'",
       ],
       datasourceTemplate: 'pypi',
       depNameTemplate: 'commitizen',
@@ -61,7 +61,7 @@
       matchStringsStrategy: 'recursive',
       matchStrings: [
         "uses: reviewdog/action-setup@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: '[^'\\s]+'",
-        "reviewdog_version: '(?<currentValue>[^'\\s]+)'",
+        "\\n\\s+reviewdog_version: '(?<currentValue>[^'\\s]+)'",
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'reviewdog/reviewdog',
@@ -85,7 +85,7 @@
       matchStringsStrategy: 'recursive',
       matchStrings: [
         "uses: tombi-toml/setup-tombi@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '[^'\\s]+'",
-        "version: '(?<currentValue>[^'\\s]+)'",
+        "\\n\\s+version: '(?<currentValue>[^'\\s]+)'",
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'tombi-toml/tombi',
@@ -109,7 +109,7 @@
       matchStringsStrategy: 'recursive',
       matchStrings: [
         "uses: j178/prek-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: '[^'\\s]+'",
-        "prek-version: '(?<currentValue>[^'\\s]+)'",
+        "\\n\\s+prek-version: '(?<currentValue>[^'\\s]+)'",
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'j178/prek',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,10 +10,11 @@
       managerFilePatterns: [
         '/^\\.github/workflows/.*\\.ya?ml$/',
       ],
+      matchStringsStrategy: 'recursive',
       matchStrings: [
-        "uses: commitizen-tools/setup-cz@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: ')(?<currentValue>[^'\\s]+)'",
+        "uses: commitizen-tools/setup-cz@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '[^'\\s]+'",
+        "version: '(?<currentValue>[^'\\s]+)'",
       ],
-      autoReplaceStringTemplate: "uses: commitizen-tools/setup-cz@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'pypi',
       depNameTemplate: 'commitizen',
     },
@@ -57,10 +58,11 @@
       managerFilePatterns: [
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
+      matchStringsStrategy: 'recursive',
       matchStrings: [
-        "uses: reviewdog/action-setup@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: ')(?<currentValue>[^'\\s]+)'",
+        "uses: reviewdog/action-setup@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: '[^'\\s]+'",
+        "reviewdog_version: '(?<currentValue>[^'\\s]+)'",
       ],
-      autoReplaceStringTemplate: "uses: reviewdog/action-setup@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'reviewdog/reviewdog',
     },
@@ -80,10 +82,11 @@
       managerFilePatterns: [
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
+      matchStringsStrategy: 'recursive',
       matchStrings: [
-        "uses: tombi-toml/setup-tombi@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: ')(?<currentValue>[^'\\s]+)'",
+        "uses: tombi-toml/setup-tombi@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '[^'\\s]+'",
+        "version: '(?<currentValue>[^'\\s]+)'",
       ],
-      autoReplaceStringTemplate: "uses: tombi-toml/setup-tombi@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'tombi-toml/tombi',
     },
@@ -103,10 +106,11 @@
       managerFilePatterns: [
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
+      matchStringsStrategy: 'recursive',
       matchStrings: [
-        "uses: j178/prek-action@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: ')(?<currentValue>[^'\\s]+)'",
+        "uses: j178/prek-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: '[^'\\s]+'",
+        "prek-version: '(?<currentValue>[^'\\s]+)'",
       ],
-      autoReplaceStringTemplate: "uses: j178/prek-action@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'j178/prek',
     },


### PR DESCRIPTION
The custom regex managers that track a tool version inside an action's `with` block (commitizen, reviewdog, tombi, prek) captured the digest, pin comment and `with` block into a named group `prefix` and rebuilt it via `autoReplaceStringTemplate`. Renovate only exposes the reserved capture groups to templates, so `{{{prefix}}}` rendered to an empty string and the autoreplace collapsed the whole block (e.g. to `uses: j178/prek-action@v0.4.5'`), making `ci.yaml` unparseable. Renovate then failed branch creation with "update failure" (visible for `j178/prek` and `tombi-toml/tombi`; `commitizen` and `reviewdog` were latently affected).

- Switch these four managers to `matchStringsStrategy: recursive`: the outer match anchors on the action, the inner match isolates only the version value.
- The `replaceString` becomes just the version field, so the action pin comment is left untouched without relying on an unsupported capture group.
