### PR TITLE
chore(renovate): scope full-semver rule to action depType

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -120,6 +120,9 @@
       matchManagers: [
         'github-actions',
       ],
+      matchDepTypes: [
+        'action',
+      ],
       allowedVersions: '/^v?\\d+\\.\\d+\\.\\d+$/',
     },
     {


### PR DESCRIPTION
Follow-up to #377. The `github-actions` manager extracts more than `uses:` action references — per the docs it also produces the `uses-with`, `container`, `service`, `github-runner`, and `docker` depTypes. The previous rule applied the full-semver `allowedVersions` filter to all of them, so a runtime input such as `node-version: 24` (depType `uses-with`) on `actions/setup-node` could be suppressed or rewritten.

Scope the rule to `matchDepTypes: ['action']` so it only constrains `uses:` action tags and leaves runtime/tool versions untouched.
