### PR TITLE
chore(renovate): group zizmor-action and zizmor docker tag updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -127,9 +127,10 @@
     },
     {
       matchDepNames: [
-        'crate-ci/typos',
+        'commitizen-tools/commitizen',
+        'commitizen',
       ],
-      groupName: 'typos',
+      groupName: 'commitizen',
     },
     {
       matchDepNames: [
@@ -140,6 +141,12 @@
     },
     {
       matchDepNames: [
+        'crate-ci/typos',
+      ],
+      groupName: 'typos',
+    },
+    {
+      matchDepNames: [
         'adrienverge/yamllint',
         'yamllint',
       ],
@@ -147,10 +154,10 @@
     },
     {
       matchDepNames: [
-        'commitizen-tools/commitizen',
-        'commitizen',
+        'zizmorcore/zizmor-action',
+        'ghcr.io/zizmorcore/zizmor',
       ],
-      groupName: 'commitizen',
+      groupName: 'zizmor',
     },
     {
       matchFileNames: [


### PR DESCRIPTION
Group `zizmorcore/zizmor-action` and the `ghcr.io/zizmorcore/zizmor` docker tag into a single PR via a shared `groupName: 'zizmor'`.

These two are released in lockstep (the action ships within ~24h of each zizmor release, well inside the 3-day `minimumReleaseAge` cooldown), so grouping makes the action and the zizmor binary it runs update together. This avoids CI failures caused by a standalone docker-tag bump landing a zizmor version the pinned action does not yet support.

Also sort the existing group rules alphabetically by `groupName`.
