### PR TITLE
chore(renovate): hold zizmor image one day longer than the action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -153,6 +153,12 @@
       groupName: 'commitizen',
     },
     {
+      matchDepNames: [
+        'ghcr.io/zizmorcore/zizmor',
+      ],
+      minimumReleaseAge: '4 days',
+    },
+    {
       matchFileNames: [
         '.github/workflows/**',
       ],


### PR DESCRIPTION
Raise `minimumReleaseAge` for the `ghcr.io/zizmorcore/zizmor` image to 4 days (vs. the global 3 days).

The zizmor binary is published roughly a day before the matching `zizmorcore/zizmor-action` release. With the global 3-day age, the image can become eligible while the action update is still pending, letting an image-only bump land a zizmor version the pinned action cannot yet run (CI failure). Holding the image to 4 days ensures it never becomes eligible before the action, so the compatible action update is always available alongside it.

This intentionally does not group the two dependencies, so the action can still be updated independently when desired.
