### PR TITLE
chore(renovate): group tombi dependencies and sort group rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -127,9 +127,10 @@
     },
     {
       matchDepNames: [
-        'crate-ci/typos',
+        'commitizen-tools/commitizen',
+        'commitizen',
       ],
-      groupName: 'typos',
+      groupName: 'commitizen',
     },
     {
       matchDepNames: [
@@ -140,17 +141,24 @@
     },
     {
       matchDepNames: [
+        'tombi-toml/setup-tombi',
+        'tombi-toml/tombi',
+        'tombi-toml/tombi-pre-commit',
+      ],
+      groupName: 'tombi',
+    },
+    {
+      matchDepNames: [
+        'crate-ci/typos',
+      ],
+      groupName: 'typos',
+    },
+    {
+      matchDepNames: [
         'adrienverge/yamllint',
         'yamllint',
       ],
       groupName: 'yamllint',
-    },
-    {
-      matchDepNames: [
-        'commitizen-tools/commitizen',
-        'commitizen',
-      ],
-      groupName: 'commitizen',
     },
     {
       matchDepNames: [


### PR DESCRIPTION
Group the three tombi dependencies into one `tombi` group:

- `tombi-toml/tombi` — the binary version pinned via the `setup-tombi` `version:` input
- `tombi-toml/setup-tombi` — the CI action
- `tombi-toml/tombi-pre-commit` — the pre-commit hook

All three are auto-released from the tombi release pipeline (`setup-tombi` and `tombi-pre-commit` are dispatched on each stable tag) and share the same version, so bundling them keeps the CI and pre-commit pins aligned in one PR.

Also sort the existing group rules alphabetically by `groupName` (commitizen, markdownlint-cli2, tombi, typos, yamllint).
