### PR TITLE
refactor(renovate): unify customManager depNames to org/name form

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,7 +16,8 @@
         "\\n\\s+version: '(?<currentValue>[^'\\s]+)'",
       ],
       datasourceTemplate: 'pypi',
-      depNameTemplate: 'commitizen',
+      depNameTemplate: 'commitizen-tools/commitizen',
+      packageNameTemplate: 'commitizen',
     },
     {
       customType: 'regex',
@@ -40,7 +41,8 @@
         'renovate@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
-      depNameTemplate: 'renovate',
+      depNameTemplate: 'renovatebot/renovate',
+      packageNameTemplate: 'renovate',
     },
     {
       customType: 'regex',
@@ -51,7 +53,8 @@
         'markdownlint-cli2@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
-      depNameTemplate: 'markdownlint-cli2',
+      depNameTemplate: 'DavidAnson/markdownlint-cli2',
+      packageNameTemplate: 'markdownlint-cli2',
     },
     {
       customType: 'regex',
@@ -75,7 +78,8 @@
         'json5@(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'npm',
-      depNameTemplate: 'json5',
+      depNameTemplate: 'json5/json5',
+      packageNameTemplate: 'json5',
     },
     {
       customType: 'regex',
@@ -99,7 +103,8 @@
         'yamllint==(?<currentValue>[^"\\s]+)',
       ],
       datasourceTemplate: 'pypi',
-      depNameTemplate: 'yamllint',
+      depNameTemplate: 'adrienverge/yamllint',
+      packageNameTemplate: 'yamllint',
     },
     {
       customType: 'regex',
@@ -128,14 +133,12 @@
     {
       matchDepNames: [
         'commitizen-tools/commitizen',
-        'commitizen',
       ],
       groupName: 'commitizen',
     },
     {
       matchDepNames: [
         'DavidAnson/markdownlint-cli2',
-        'markdownlint-cli2',
       ],
       groupName: 'markdownlint-cli2',
     },
@@ -156,7 +159,6 @@
     {
       matchDepNames: [
         'adrienverge/yamllint',
-        'yamllint',
       ],
       groupName: 'yamllint',
     },
@@ -193,7 +195,7 @@
     },
     {
       matchDepNames: [
-        'renovate',
+        'renovatebot/renovate',
       ],
       matchFileNames: [
         '.github/workflows/ci.yaml',
@@ -205,7 +207,7 @@
     },
     {
       matchDepNames: [
-        'renovate',
+        'renovatebot/renovate',
       ],
       matchFileNames: [
         '.github/workflows/ci.yaml',


### PR DESCRIPTION
Unify every customManager `depNameTemplate` to the `org/name` form, matching the depNames Renovate already derives for the pre-commit hooks. The npm/pypi lookup is preserved via `packageNameTemplate`.

- `commitizen` → `commitizen-tools/commitizen`
- `yamllint` → `adrienverge/yamllint`
- `markdownlint-cli2` → `DavidAnson/markdownlint-cli2`
- `json5` → `json5/json5`
- `renovate` → `renovatebot/renovate`

With CI and pre-commit now sharing one depName, the `commitizen`, `markdownlint-cli2` and `yamllint` groups collapse to a single `matchDepNames` entry (like `typos`); genuinely separate sources such as `tombi` stay explicit. The `renovate` packageRules `matchDepNames` are updated to `renovatebot/renovate` to match.

Validated with `renovate-config-validator`.
