### PR TITLE
ci: split changed JSON5 file list on newlines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          safe_output: false
           separator: "\n"
           files_yaml: |
             github_actions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
+          separator: "\n"
           files_yaml: |
             github_actions:
               - .github/workflows/**
@@ -204,7 +205,7 @@ jobs:
           CHANGED_JSON5_FILES: ${{ needs.determine-changes.outputs.json5_files }}
         run: |
           readarray -t json5_files < <(
-            printf '%s\n' "${CHANGED_JSON5_FILES}" | tr ' ' '\n' | sed '/^$/d'
+            printf '%s\n' "${CHANGED_JSON5_FILES}" | sed '/^$/d'
           )
           if [ ${#json5_files[@]} -eq 0 ]; then
             readarray -d '' -t json5_files < <(


### PR DESCRIPTION
The `lint-json5` job split the changed-files output with `tr ' ' '\n'`, so a JSON5 path containing spaces was broken into multiple nonexistent paths and validation failed.

- Set `separator: "\n"` on the `tj-actions/changed-files` step so file lists are newline-delimited.
- Drop the `tr`-based splitting in the `lint-json5` job and split on newlines only.
