### PR TITLE
ci: skip commit message lint when base commit is unavailable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -398,7 +398,15 @@ jobs:
 
       - name: Lint commit messages on push
         if: github.event_name == 'push'
-        run: cz check --rev-range ${{ github.event.before }}..${{ github.sha }}
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            echo "::notice title=cz check::Base commit unavailable (new branch or force push); skipping lint."
+            exit 0
+          fi
+          cz check --rev-range "${BEFORE_SHA}..${HEAD_SHA}"
 
       - name: Lint commit messages on pull request
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
On push events, `github.event.before` is the zero SHA when a branch is created and can reference an unreachable commit after a force push. In both cases `cz check --rev-range` failed.

- Check that the base commit exists with `git cat-file -e` and skip the lint with a notice when it does not.
- Pass the SHAs through environment variables instead of interpolating them into the script.
