### PR TITLE
ci: deny default token permissions in bump-version and sync-labels

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -14,6 +14,8 @@ on:
           - minor
           - patch
 
+permissions: {}
+
 jobs:
 
   bump-version:

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/sync-labels.yaml'
       - '.github/labels/label-definition.yaml'
 
+permissions: {}
+
 jobs:
 
   sync-labels:


### PR DESCRIPTION
`bump-version.yaml` and `sync-labels.yaml` only granted permissions at the job level, so the workflow-level default token permissions still applied to the workflow as a whole (flagged by zizmor's `excessive-permissions` audit).

- Add a top-level `permissions: {}` to both workflows, matching `manage-pull-requests.yaml`. Job-level grants are unchanged.
