### PR TITLE
chore(yamllint): drop truthy exception by quoting workflow on keys

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,6 +1,6 @@
 name: Bump Version
 
-on:
+'on':
   pull_request:
     types: [closed]
   workflow_dispatch:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on:
+'on':
   push:
     branches:
       - main

--- a/.github/workflows/manage-pull-requests.yaml
+++ b/.github/workflows/manage-pull-requests.yaml
@@ -1,6 +1,6 @@
 name: Manage Pull Requests
 
-on:
+'on':
   pull_request:
     types: [opened, synchronize, reopened, edited]
 

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,6 +1,6 @@
 name: Sync Labels
 
-on:
+'on':
   workflow_dispatch:
   push:
     branches:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -8,9 +8,7 @@ rules:
       .github/workflows/*.yml
       .github/workflows/*.yaml
   truthy:
-    ignore: |
-      .github/workflows/*.yml
-      .github/workflows/*.yaml
+    check-keys: false
   comments:
     ignore: |
       .github/workflows/*.yml

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,8 +7,6 @@ rules:
     ignore: |
       .github/workflows/*.yml
       .github/workflows/*.yaml
-  truthy:
-    check-keys: false
   comments:
     ignore: |
       .github/workflows/*.yml


### PR DESCRIPTION
The truthy rule ignored workflow files entirely, so truthy values (e.g. an unquoted `yes`) in them were never checked; the ignore only existed to allow the `on:` workflow key.

An intermediate `check-keys: false` approach was reverted after review, since it disabled truthy key checks for every YAML file, not just workflows.

- Quote the `on` key in the workflow files, which is the only unavoidable truthy key.
- Drop the truthy exception from `.yamllint.yaml` entirely, so both keys and values are checked in all YAML files.
