### PR TITLE
ci(bump-version): add merged guard and use inputs context

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -31,6 +31,6 @@ jobs:
           label-major: 'update::major'
           label-minor: 'update::minor'
           label-patch: 'update::patch'
-          manual-bump-type: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump_type || '' }}
+          manual-bump-type: ${{ inputs.bump_type }}
           labels-to-add: 'automated,versioning'
           create-release: 'true'

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -19,6 +19,7 @@ permissions: {}
 jobs:
 
   bump-version:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Two small refinements to the bump-version workflow, one per commit:

- Add a job-level `if` so closed-but-unmerged pull requests no longer provision a runner. The condition mirrors the action's internal guard and follows the pattern recommended by the GitHub Actions docs for the `closed` activity type. This also avoids the 1-minute billing round-up per closed PR in private repositories derived from this template.
- Pass the manual bump type via the `inputs` context (`${{ inputs.bump_type }}`). It is the current canonical form, preserves input types, and resolves to an empty string on `pull_request` events, making the previous event-name guard unnecessary. No behavioral change.
