### PR TITLE
ci: set a 10-minute timeout on every job

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -21,6 +21,7 @@ jobs:
   bump-version:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
   determine-changes:
     name: Determine changed files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       github_actions: ${{ steps.changed-files.outputs.github_actions_any_changed }}
       github_actions_ci: ${{ steps.changed-files.outputs.github_actions_ci_any_changed }}
@@ -67,6 +68,7 @@ jobs:
     needs: determine-changes
     if: ${{ needs.determine-changes.outputs.github_actions == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -119,6 +121,7 @@ jobs:
       ${{ needs.determine-changes.outputs.renovate_config == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -145,6 +148,7 @@ jobs:
       ${{ needs.determine-changes.outputs.md == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -192,6 +196,7 @@ jobs:
       ${{ needs.determine-changes.outputs.json5 == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -230,6 +235,7 @@ jobs:
       ${{ needs.determine-changes.outputs.toml == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -305,6 +311,7 @@ jobs:
       ${{ needs.determine-changes.outputs.yaml == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -337,6 +344,7 @@ jobs:
   check-prek:
     name: Check prek
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout the main repository
@@ -353,6 +361,7 @@ jobs:
   check-typos:
     name: Check typos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: write
@@ -380,6 +389,7 @@ jobs:
   lint-commit-messages:
     name: Lint commit messages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout the main repository

--- a/.github/workflows/manage-pull-requests.yaml
+++ b/.github/workflows/manage-pull-requests.yaml
@@ -15,6 +15,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
@@ -28,6 +29,7 @@ jobs:
     name: Lint PR title
     if: github.event.action != 'edited' || github.event.changes.title != null
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Set up Commitizen

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -21,6 +21,7 @@ jobs:
   sync-labels:
     name: Sync Labels
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Jobs without `timeout-minutes` fall back to the 6-hour default, so a hung runner occupies its slot (and, in private repositories derived from this template, billable minutes) for hours.

Add a uniform `timeout-minutes: 10` to every job across the four workflows. All jobs are short lint or automation tasks — the observed worst case in recent CI history is under one minute — so 10 minutes leaves more than 10x headroom against transient slowness while capping hangs. Derived repositories can raise the value for heavier jobs they add.
