### PR TITLE
chore(markdownlint): exempt tables from MD013

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,3 +4,4 @@ gitignore: true
 config:
   MD013:
     line_length: 120
+    tables: false


### PR DESCRIPTION
Configure `MD013` with `tables: false` so table rows are exempt from the line-length limit.

Table rows cannot be wrapped, so the limit is unenforceable there and any wide table would need inline `markdownlint-disable`/`enable` directives to pass.
No current Markdown file is affected; this keeps the template's lint configuration usable once a wide table is added.

The exemption is scoped to blocks the parser recognizes as tables, so it does not loosen the limit anywhere else.
