### PR TITLE
chore(renovate): resolve zizmor image version via GitHub Releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -166,7 +166,10 @@
       matchDepNames: [
         'ghcr.io/zizmorcore/zizmor',
       ],
+      overrideDatasource: 'github-releases',
+      overridePackageName: 'zizmorcore/zizmor',
       minimumReleaseAge: '4 days',
+      pinDigests: false,
     },
     {
       matchFileNames: [


### PR DESCRIPTION
Renovate detects the zizmor image through its github-actions manager, which maps the `version` input of `zizmorcore/zizmor-action` to the docker datasource `ghcr.io/zizmorcore/zizmor`.
GHCR does not return release timestamps, and since Renovate 42 a missing timestamp is treated as "not yet aged", so `minimumReleaseAge` can never be satisfied.
As a result #324 has had a pending `renovate/stability-days` check ever since it was opened, and the branch is no longer refreshed to newer releases.

- Override the datasource to `github-releases` (`zizmorcore/zizmor`) so lookups carry a real `publishedAt` timestamp and the four-day hold added in #383 works as intended.
- Disable `pinDigests` for this dependency, since `docker:pinDigests` from `config:best-practices` is evaluated before the override and a commit SHA is meaningless for this input.

`depName` is unchanged, so #324 keeps its branch and should be updated in place on the next run.
